### PR TITLE
Update jquery-ui to 1.12.0 and fix dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
-    "jquery-ui": "~1.11.4",
+    "jquery-ui": "~1.12.0",
     "jquery-simulate": "~1.0.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ module.exports = {
   name: 'ember-ui-sortable',
 
   included: function(app) {
-    app.import(app.bowerDirectory + '/jquery-ui/ui/core.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/data.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/scroll-parent.js');
     app.import(app.bowerDirectory + '/jquery-ui/ui/widget.js');
-    app.import(app.bowerDirectory + '/jquery-ui/ui/mouse.js');
-    app.import(app.bowerDirectory + '/jquery-ui/ui/sortable.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/widgets/mouse.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/widgets/sortable.js');
   }
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ module.exports = {
   name: 'ember-ui-sortable',
 
   included: function(app) {
+    app.import(app.bowerDirectory + '/jquery-ui/ui/version.js');
     app.import(app.bowerDirectory + '/jquery-ui/ui/data.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/ie.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/safe-active-element.js');
+    app.import(app.bowerDirectory + '/jquery-ui/ui/safe-blur.js');
     app.import(app.bowerDirectory + '/jquery-ui/ui/scroll-parent.js');
     app.import(app.bowerDirectory + '/jquery-ui/ui/widget.js');
     app.import(app.bowerDirectory + '/jquery-ui/ui/widgets/mouse.js');


### PR DESCRIPTION
As the addon by default adds the latest version of jquery-ui to your ember project and jquery-ui 1.12 changed the folder layout, the addon stopped installing correctly.

This PR fixes that and includes only minimal dependencies to work (so not the whole core.js). Core.js is also deprecated in 1.12 to be removed in 1.13.
